### PR TITLE
MOBILE-3556 Login: Send extra parameter on token.php check

### DIFF
--- a/src/providers/sites.ts
+++ b/src/providers/sites.ts
@@ -641,7 +641,8 @@ export class CoreSitesProvider {
      * @return A promise to be resolved if the site exists.
      */
     siteExists(siteUrl: string): Promise<void> {
-        return this.http.post(siteUrl + '/login/token.php', {}).timeout(this.wsProvider.getRequestTimeout()).toPromise()
+        return this.http.post(siteUrl + '/login/token.php', { appsitecheck: 1 }).
+                timeout(this.wsProvider.getRequestTimeout()).toPromise()
                 .catch(() => {
             // Default error messages are kinda bad, return our own message.
             return Promise.reject({error: this.translate.instant('core.cannotconnecttrouble')});


### PR DESCRIPTION
The extra parameter can be used by Moodle to avoid throwing an error
in server logs because other parameters e.g. username are not supplied.