### PR TITLE
Use docker-layer cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 # Delete caches.
-RUN rm -rf /root/.npmCOPY . /app
+RUN rm -rf /root/.npm
+
+COPY . /app
 
 # Run gulp before starting.
 RUN npx gulp

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ EXPOSE 53703
 
 WORKDIR /app
 
-COPY . /app
-
 # Install npm libraries.
-RUN npm install && rm -rf /root/.npm
+COPY package*.json ./
+RUN npm ci
+# Delete caches.
+RUN rm -rf /root/.npmCOPY . /app
 
 # Run gulp before starting.
 RUN npx gulp


### PR DESCRIPTION
Docker can cache each individual layer. 
If a layer changes, each subsequent layer is repeated. A file change counts as a change and therefore it is stupid to install the libraries after everything has been copied. Furthermore, they should be installed using ```npm ci```, otherwise ```package-lock.json``` will be ignored and errors may occur as a result.