### PR TITLE
MOBILE-3320 calendar: Fix timezone in ion-datetime

### DIFF
--- a/src/addons/calendar/pages/edit-event/edit-event.html
+++ b/src/addons/calendar/pages/edit-event/edit-event.html
@@ -29,7 +29,7 @@
                     <p class="item-heading" [core-mark-required]="true">{{ 'core.date' | translate }}</p>
                 </ion-label>
                 <ion-datetime formControlName="timestart" [placeholder]="'core.date' | translate" [displayFormat]="dateFormat"
-                    [max]="maxDate" [min]="minDate">
+                    [max]="maxDate" [min]="minDate" display-timezone="utc">
                 </ion-datetime>
                 <core-input-errors [control]="form.controls.timestart" [errorMessages]="errors"></core-input-errors>
             </ion-item>
@@ -166,7 +166,8 @@
                         <ion-item>
                             <ion-datetime formControlName="timedurationuntil" [max]="maxDate" [min]="minDate"
                                 [placeholder]="'addon.calendar.durationuntil' | translate" slot="end"
-                                [displayFormat]="dateFormat" [disabled]="form.controls.duration.value != 1">
+                                [displayFormat]="dateFormat" [disabled]="form.controls.duration.value != 1"
+                                display-timezone="utc">
                             </ion-datetime>
                         </ion-item>
                         <ion-item lines="none">

--- a/src/addons/mod/data/fields/date/component/addon-mod-data-field-date.html
+++ b/src/addons/mod/data/fields/date/component/addon-mod-data-field-date.html
@@ -1,7 +1,7 @@
 <span *ngIf="inputMode && form" [formGroup]="form">
     <span *ngIf="editMode" [core-mark-required]="field.required" class="core-mark-required"></span>
     <ion-datetime [formControlName]="'f_'+field.id" [placeholder]="'core.date' | translate" [max]="maxDate" [min]="minDate"
-        [disabled]="searchMode && !searchFields!['f_'+field.id+'_z']" [displayFormat]="format">
+        [disabled]="searchMode && !searchFields!['f_'+field.id+'_z']" [displayFormat]="format" display-timezone="utc">
     </ion-datetime>
     <core-input-errors *ngIf="error && editMode" [control]="form.controls['f_'+field.id]" [errorText]="error"></core-input-errors>
 


### PR DESCRIPTION
This is a temporary fix, it should be considered further in MOBILE-3784