### PR TITLE
MOBILE-3320: Fix regressions

### DIFF
--- a/src/addons/calendar/components/filter/filter.ts
+++ b/src/addons/calendar/components/filter/filter.ts
@@ -59,7 +59,7 @@ export class AddonCalendarFilterPopoverComponent implements OnInit {
      * Init the component.
      */
     ngOnInit(): void {
-        this.courseId = this.filter.courseId + '';
+        this.courseId = (this.filter.courseId || -1) + '';
     }
 
     /**

--- a/src/addons/messages/pages/search/search.html
+++ b/src/addons/messages/pages/search/search.html
@@ -50,7 +50,7 @@
                 <p class="item-heading">
                     <core-format-text [text]="result.fullname" [highlight]="result.highlightName" [filter]="false">
                     </core-format-text>
-                    <ion-icon name="fa-ban" *ngIf="result.isblocked"
+                    <ion-icon name="fas-ban" *ngIf="result.isblocked"
                         [attr.aria-label]="'addon.messages.contactblocked' | translate">
                     </ion-icon>
                 </p>

--- a/src/addons/mod/data/services/data-helper.ts
+++ b/src/addons/mod/data/services/data-helper.ts
@@ -658,7 +658,7 @@ export class AddonModDataHelperProvider {
         // Add core-link directive to links.
         template = template.replace(
             /<a ([^>]*href="[^>]*)>/ig,
-            (match, attributes) => '<button class="as-link" core-link capture="true" ' + attributes + '>',
+            (match, attributes) => '<a core-link capture="true" ' + attributes + '>',
         );
 
         return template;

--- a/src/addons/mod/forum/components/discussion-options-menu/discussion-options-menu.html
+++ b/src/addons/mod/forum/components/discussion-options-menu/discussion-options-menu.html
@@ -1,37 +1,37 @@
 <ion-item button class="ion-text-wrap" (click)="setLockState(true)" *ngIf="discussion.canlock && !discussion.locked" detail="false">
-    <ion-icon name="fa-lock" slot="start" aria-hidden="true"></ion-icon>
+    <ion-icon name="fas-lock" slot="start" aria-hidden="true"></ion-icon>
     <ion-label>
         <p class="item-heading">{{ 'addon.mod_forum.lockdiscussion' | translate }}</p>
     </ion-label>
 </ion-item>
 <ion-item button class="ion-text-wrap" (click)="setLockState(false)" *ngIf="discussion.canlock && discussion.locked" detail="false">
-    <ion-icon name="fa-unlock" slot="start" aria-hidden="true"></ion-icon>
+    <ion-icon name="fas-unlock" slot="start" aria-hidden="true"></ion-icon>
     <ion-label>
         <p class="item-heading">{{ 'addon.mod_forum.unlockdiscussion' | translate }}</p>
     </ion-label>
 </ion-item>
 <ion-item button class="ion-text-wrap" (click)="setPinState(true)" *ngIf="canPin && !discussion.pinned" detail="false">
-    <ion-icon name="fa-map-pin" slot="start" aria-hidden="true"></ion-icon>
+    <ion-icon name="fas-map-pin" slot="start" aria-hidden="true"></ion-icon>
     <ion-label>
         <p class="item-heading">{{ 'addon.mod_forum.pindiscussion' | translate }}</p>
     </ion-label>
 </ion-item>
 <ion-item button class="ion-text-wrap" (click)="setPinState(false)" *ngIf="canPin && discussion.pinned" detail="false">
-    <ion-icon name="fa-map-pin" slot="start" class="icon-slash" aria-hidden="true"></ion-icon>
+    <ion-icon name="fas-map-pin" slot="start" class="icon-slash" aria-hidden="true"></ion-icon>
     <ion-label>
         <p class="item-heading">{{ 'addon.mod_forum.unpindiscussion' | translate }}</p>
     </ion-label>
 </ion-item>
 <ion-item button class="ion-text-wrap" (click)="toggleFavouriteState(true)" *ngIf="discussion.canfavourite && !discussion.starred"
     detail="false">
-    <ion-icon name="fa-star" slot="start" aria-hidden="true"></ion-icon>
+    <ion-icon name="fas-star" slot="start" aria-hidden="true"></ion-icon>
     <ion-label>
         <p class="item-heading">{{ 'addon.mod_forum.addtofavourites' | translate }}</p>
     </ion-label>
 </ion-item>
 <ion-item button class="ion-text-wrap" (click)="toggleFavouriteState(false)" *ngIf="discussion.canfavourite && discussion.starred"
     detail="false">
-    <ion-icon name="fa-star" slot="start" class="icon-slash" aria-hidden="true"></ion-icon>
+    <ion-icon name="fas-star" slot="start" class="icon-slash" aria-hidden="true"></ion-icon>
     <ion-label>
         <p class="item-heading">{{ 'addon.mod_forum.removefromfavourites' | translate }}</p>
     </ion-label>

--- a/src/addons/mod/forum/components/edit-post/edit-post.html
+++ b/src/addons/mod/forum/components/edit-post/edit-post.html
@@ -34,8 +34,8 @@
             aria-controls="addon-mod-forum-advanced"
             [attr.aria-label]="(advanced ? 'core.hideadvanced' : 'core.showadvanced') | translate"
         >
-            <ion-icon *ngIf="!advanced" name="fa-caret-right" flip-rtl slot="start" aria-hidden="true"></ion-icon>
-            <ion-icon *ngIf="advanced" name="fa-caret-down" slot="start" aria-hidden="true"></ion-icon>
+            <ion-icon *ngIf="!advanced" name="fas-caret-right" flip-rtl slot="start" aria-hidden="true"></ion-icon>
+            <ion-icon *ngIf="advanced" name="fas-caret-down" slot="start" aria-hidden="true"></ion-icon>
             <ion-label><h2>{{ 'addon.mod_forum.advanced' | translate }}</h2></ion-label>
         </ion-item>
         <div *ngIf="advanced" id="addon-mod-forum-advanced">

--- a/src/addons/mod/forum/components/index/index.html
+++ b/src/addons/mod/forum/components/index/index.html
@@ -30,7 +30,7 @@
             (action)="removeFiles($event)">
         </core-context-menu-item>
         <core-context-menu-item *ngIf="sortingAvailable"
-            iconAction="fa-sort"
+            iconAction="fas-sort"
             [priority]="300" [content]="'core.sort' | translate"
             (action)="showSortOrderSelector()">
         </core-context-menu-item>
@@ -93,9 +93,9 @@
                 <ion-label>
                     <div class="addon-mod-forum-discussion-title">
                         <p class="ion-text-wrap item-heading">
-                            <ion-icon name="fa-map-pin" *ngIf="discussion.pinned"
+                            <ion-icon name="fas-map-pin" *ngIf="discussion.pinned"
                                 [attr.aria-label]="'addon.mod_forum.discussionpinned' | translate"></ion-icon>
-                            <ion-icon name="fa-star" class="addon-forum-star" *ngIf="!discussion.pinned && discussion.starred"
+                            <ion-icon name="fas-star" class="addon-forum-star" *ngIf="!discussion.pinned && discussion.starred"
                                 [attr.aria-label]="'addon.mod_forum.favourites' | translate"></ion-icon>
                             <core-format-text
                                 [text]="discussion.subject"

--- a/src/addons/mod/forum/components/post/post.html
+++ b/src/addons/mod/forum/components/post/post.html
@@ -4,10 +4,10 @@
             <ion-label>
                 <div class="addon-mod-forum-post-title" *ngIf="displaySubject">
                     <h2 class="ion-text-wrap">
-                        <ion-icon name="fa-map-pin" *ngIf="discussion && !post.parentid && discussion.pinned"
+                        <ion-icon name="fas-map-pin" *ngIf="discussion && !post.parentid && discussion.pinned"
                             [attr.aria-label]="'addon.mod_forum.discussionpinned' | translate">
                         </ion-icon>
-                        <ion-icon name="fa-star" class="addon-forum-star"
+                        <ion-icon name="fas-star" class="addon-forum-star"
                             [attr.aria-label]="'addon.mod_forum.favourites' | translate"
                             *ngIf="discussion && !post.parentid && !discussion.pinned && discussion.starred">
                         </ion-icon>
@@ -18,7 +18,7 @@
                     </h2>
                     <ion-note *ngIf="trackPosts && post.unread"
                         class="ion-float-end ion-padding-left ion-text-end" [attr.aria-label]="'addon.mod_forum.unread' | translate">
-                        <ion-icon name="fa-circle" color="primary" aria-hidden="true"></ion-icon>
+                        <ion-icon name="fas-circle" color="primary" aria-hidden="true"></ion-icon>
                     </ion-note>
                     <ion-button *ngIf="optionsMenuEnabled"
                         fill="clear" color="dark" [attr.aria-label]="('core.displayoptions' | translate)"
@@ -46,7 +46,7 @@
                     <ng-container *ngIf="!displaySubject">
                         <ion-note *ngIf="trackPosts && post.unread"
                             class="ion-float-end ion-padding-left ion-text-end" [attr.aria-label]="'addon.mod_forum.unread' | translate">
-                            <ion-icon name="fa-circle" color="primary" aria-hidden="true"></ion-icon>
+                            <ion-icon name="fas-circle" color="primary" aria-hidden="true"></ion-icon>
                         </ion-note>
                         <ion-button *ngIf="optionsMenuEnabled"
                             fill="clear" color="dark" [attr.aria-label]="('core.displayoptions' | translate)"
@@ -94,7 +94,7 @@
                     [attr.aria-controls]="'addon-forum-reply-edit-form-' + uniqueId"
                     [attr.aria-expanded]="replyData.replyingTo === post.id"
                     (click)="showReplyForm($event)">
-                    <ion-icon name="fa-reply" slot="start" aria-hidden="true"></ion-icon>
+                    <ion-icon name="fas-reply" slot="start" aria-hidden="true"></ion-icon>
                     {{ 'addon.mod_forum.reply' | translate }}
                 </ion-button>
             </ion-label>
@@ -130,8 +130,8 @@
                 [attr.aria-controls]="'addon-forum-reply-edit-form-advanced-' + uniqueId"
                 [attr.aria-label]="(advanced ? 'core.hideadvanced' : 'core.showadvanced') | translate"
             >
-                <ion-icon *ngIf="!advanced" name="fa-caret-right" flip-rtl slot="start" aria-hidden="true"></ion-icon>
-                <ion-icon *ngIf="advanced" name="fa-caret-down" slot="start" aria-hidden="true"></ion-icon>
+                <ion-icon *ngIf="!advanced" name="fas-caret-right" flip-rtl slot="start" aria-hidden="true"></ion-icon>
+                <ion-icon *ngIf="advanced" name="fas-caret-down" slot="start" aria-hidden="true"></ion-icon>
                 <ion-label>
                     <h2>{{ 'addon.mod_forum.advanced' | translate }}</h2>
                 </ion-label>

--- a/src/addons/mod/forum/pages/discussion/discussion.html
+++ b/src/addons/mod/forum/pages/discussion/discussion.html
@@ -23,15 +23,15 @@
             (action)="doRefresh(null, $event, true)">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="sort == 'flat-oldest'"
-            [priority]="500" [content]="'addon.mod_forum.modeflatoldestfirst' | translate" iconAction="arrow-round-down"
+            [priority]="500" [content]="'addon.mod_forum.modeflatoldestfirst' | translate" iconAction="fa-arrow-down"
             (action)="changeSort('flat-oldest')">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="sort == 'flat-newest'"
-            [priority]="450" [content]="'addon.mod_forum.modeflatnewestfirst' | translate" iconAction="arrow-round-up"
+            [priority]="450" [content]="'addon.mod_forum.modeflatnewestfirst' | translate" iconAction="fa-arrow-up"
             (action)="changeSort('flat-newest')">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="sort == 'nested'"
-            [priority]="400" [content]="'addon.mod_forum.modenested' | translate" iconAction="swap"
+            [priority]="400" [content]="'addon.mod_forum.modenested' | translate" iconAction="fa-exchange-alt"
             (action)="changeSort('nested')">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="!discussion || !discussion.canlock || discussion.locked"

--- a/src/addons/mod/forum/pages/discussion/discussion.html
+++ b/src/addons/mod/forum/pages/discussion/discussion.html
@@ -23,39 +23,39 @@
             (action)="doRefresh(null, $event, true)">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="sort == 'flat-oldest'"
-            [priority]="500" [content]="'addon.mod_forum.modeflatoldestfirst' | translate" iconAction="fa-arrow-down"
+            [priority]="500" [content]="'addon.mod_forum.modeflatoldestfirst' | translate" iconAction="fas-arrow-down"
             (action)="changeSort('flat-oldest')">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="sort == 'flat-newest'"
-            [priority]="450" [content]="'addon.mod_forum.modeflatnewestfirst' | translate" iconAction="fa-arrow-up"
+            [priority]="450" [content]="'addon.mod_forum.modeflatnewestfirst' | translate" iconAction="fas-arrow-up"
             (action)="changeSort('flat-newest')">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="sort == 'nested'"
-            [priority]="400" [content]="'addon.mod_forum.modenested' | translate" iconAction="fa-exchange-alt"
+            [priority]="400" [content]="'addon.mod_forum.modenested' | translate" iconAction="fas-exchange-alt"
             (action)="changeSort('nested')">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="!discussion || !discussion.canlock || discussion.locked"
-            [priority]="300" [content]="'addon.mod_forum.lockdiscussion' | translate" iconAction="fa-lock"
+            [priority]="300" [content]="'addon.mod_forum.lockdiscussion' | translate" iconAction="fas-lock"
             (action)="setLockState(true)">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="!discussion || !discussion.canlock || !discussion.locked"
-            [priority]="300" [content]="'addon.mod_forum.unlockdiscussion' | translate" iconAction="fa-unlock"
+            [priority]="300" [content]="'addon.mod_forum.unlockdiscussion' | translate" iconAction="fas-unlock"
             (action)="setLockState(false)">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="!discussion || !canPin || discussion.pinned"
-            [priority]="250" [content]="'addon.mod_forum.pindiscussion' | translate" iconAction="fa-map-pin"
+            [priority]="250" [content]="'addon.mod_forum.pindiscussion' | translate" iconAction="fas-map-pin"
             (action)="setPinState(true)">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="!discussion || !canPin || !discussion.pinned"
-            [priority]="250" [content]="'addon.mod_forum.unpindiscussion' | translate" [iconSlash]="true" iconAction="fa-map-pin"
+            [priority]="250" [content]="'addon.mod_forum.unpindiscussion' | translate" [iconSlash]="true" iconAction="fas-map-pin"
             (action)="setPinState(false)">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="!discussion || !discussion.canfavourite || discussion.starred"
-            [priority]="200" [content]="'addon.mod_forum.addtofavourites' | translate" iconAction="fa-star"
+            [priority]="200" [content]="'addon.mod_forum.addtofavourites' | translate" iconAction="fas-star"
             (action)="toggleFavouriteState(true)">
         </core-context-menu-item>
         <core-context-menu-item [hidden]="!discussion || !discussion.canfavourite || !discussion.starred"
-            [priority]="200" [content]="'addon.mod_forum.removefromfavourites' | translate" iconAction="fa-star" [iconSlash]="true"
+            [priority]="200" [content]="'addon.mod_forum.removefromfavourites' | translate" iconAction="fas-star" [iconSlash]="true"
             (action)="toggleFavouriteState(false)">
         </core-context-menu-item>
     </core-context-menu>
@@ -84,7 +84,7 @@
 
         <ion-card class="core-info-card" *ngIf="discussion && discussion.locked">
             <ion-item>
-                <ion-icon name="fa-lock" slot="start" aria-hidden="true"></ion-icon>
+                <ion-icon name="fas-lock" slot="start" aria-hidden="true"></ion-icon>
                 <ion-label>{{ 'addon.mod_forum.discussionlocked' | translate }}</ion-label>
             </ion-item>
         </ion-card>

--- a/src/addons/mod/forum/pages/new-discussion/new-discussion.html
+++ b/src/addons/mod/forum/pages/new-discussion/new-discussion.html
@@ -41,8 +41,8 @@
                 role="heading"
                 aria-controls="addon-mod-forum-new-discussion-advanced"
             >
-                <ion-icon *ngIf="!advanced" name="fa-caret-right" flip-rtl slot="start" aria-hidden="true"></ion-icon>
-                <ion-icon *ngIf="advanced" name="fa-caret-down" slot="start" aria-hidden="true"></ion-icon>
+                <ion-icon *ngIf="!advanced" name="fas-caret-right" flip-rtl slot="start" aria-hidden="true"></ion-icon>
+                <ion-icon *ngIf="advanced" name="fas-caret-down" slot="start" aria-hidden="true"></ion-icon>
                 <ion-label><h2>{{ 'addon.mod_forum.advanced' | translate }}</h2></ion-label>
             </ion-item>
             <div *ngIf="advanced" id="addon-mod-forum-new-discussion-advanced">

--- a/src/core/features/block/classes/base-block-handler.ts
+++ b/src/core/features/block/classes/base-block-handler.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import { CoreCourseBlock } from '@features/course/services/course';
-import { CoreBlockPreRenderedComponent } from '../components/pre-rendered-block/pre-rendered-block';
 import { CoreBlockHandler, CoreBlockHandlerData } from '../services/block-delegate';
 
 /**
@@ -48,14 +47,9 @@ export class CoreBlockBaseHandler implements CoreBlockHandler {
         block: CoreCourseBlock, // eslint-disable-line @typescript-eslint/no-unused-vars
         contextLevel: string, // eslint-disable-line @typescript-eslint/no-unused-vars
         instanceId: number, // eslint-disable-line @typescript-eslint/no-unused-vars
-    ): CoreBlockHandlerData | Promise<CoreBlockHandlerData> {
-
+    ): undefined | CoreBlockHandlerData | Promise<CoreBlockHandlerData> {
         // To be overridden.
-        return {
-            title: '',
-            class: '',
-            component: CoreBlockPreRenderedComponent,
-        };
+        return undefined;
     }
 
 }

--- a/src/core/features/block/services/block-delegate.ts
+++ b/src/core/features/block/services/block-delegate.ts
@@ -44,7 +44,7 @@ export interface CoreBlockHandler extends CoreDelegateHandler {
         block: CoreCourseBlock,
         contextLevel: string,
         instanceId: number,
-    ): CoreBlockHandlerData | Promise<CoreBlockHandlerData>;
+    ): undefined | CoreBlockHandlerData | Promise<CoreBlockHandlerData>;
 }
 
 /**

--- a/src/core/features/course/pages/contents/contents.html
+++ b/src/core/features/course/pages/contents/contents.html
@@ -8,7 +8,7 @@
             [iconAction]="prefetchCourseData.icon" [closeOnClick]="false">
         </core-context-menu-item>
         <core-context-menu-item [priority]="1800" [content]="'core.course.coursesummary' | translate" (action)="openCourseSummary()"
-            iconAction="fa-graduation-cap">
+            iconAction="fas-graduation-cap">
         </core-context-menu-item>
         <core-context-menu-item *ngFor="let item of courseMenuHandlers" [priority]="item.priority" (action)="openMenuItem(item)"
             [content]="item.data.title | translate" [iconAction]="item.data.icon" [class]="item.data.class">

--- a/src/core/features/tag/pages/index/index.html
+++ b/src/core/features/tag/pages/index/index.html
@@ -30,7 +30,7 @@
                     </ion-badge>
                 </ion-item>
             </ion-list>
-            <core-empty-box icon="fa-tag" *ngIf="!hasUnsupportedAreas && (!areas || !areas.length)"
+            <core-empty-box icon="fas-tag" *ngIf="!hasUnsupportedAreas && (!areas || !areas.length)"
                 [message]="'core.tag.noresultsfor' | translate: { $a: tagName }"></core-empty-box>
         </core-loading>
     </core-split-view>

--- a/src/core/features/user/pages/about/about.html
+++ b/src/core/features/user/pages/about/about.html
@@ -90,7 +90,7 @@
             </ion-item-group>
         </ion-list>
 
-        <core-empty-box *ngIf="!user || (!hasContact && !hasDetails && !user.description)" icon="fa-user"
+        <core-empty-box *ngIf="!user || (!hasContact && !hasDetails && !user.description)" icon="fas-user"
             [message]=" 'core.user.detailsnotavailable' | translate">
         </core-empty-box>
     </core-loading>

--- a/src/core/features/user/pages/profile/profile.html
+++ b/src/core/features/user/pages/profile/profile.html
@@ -22,7 +22,7 @@
                         fill="clear"
                         color="dark"
                     >
-                        <ion-icon slot="icon-only" name="fa-pen" aria-hidden="true"></ion-icon>
+                        <ion-icon slot="icon-only" name="fas-pen" aria-hidden="true"></ion-icon>
                     </ion-button>
                 </core-user-avatar>
                 <ion-label>
@@ -55,7 +55,7 @@
 
             <ion-item button class="ion-text-wrap core-user-profile-handler" (click)="openUserDetails()"
                 [attr.aria-label]="'core.user.details' | translate" detail="true">
-                <ion-icon name="fa-user" slot="start" aria-hidden="true"></ion-icon>
+                <ion-icon name="fas-user" slot="start" aria-hidden="true"></ion-icon>
                 <ion-label>
                     <p class="item-heading">{{ 'core.user.details' | translate }}</p>
                 </ion-label>


### PR DESCRIPTION
The last commit in particular fixes database templates, that were broken in [this commit](https://github.com/moodlehq/moodleapp/commit/49f6cc56e55a503c696102946f73a4b3b96be0f5#diff-23f88613aff553b7ff16c3c2f1541eca6be80af122be539ce36247a0b6fec225R661), and I think it was a mistake done by using global replacements.

The fix may undo the a11y improvements that were introduced in that commit, but the proper solution would involve making a regex that captures the whole link (including contents and closing tag) and replacing it for a button. I think that's too risky at this stage, so it's better to just revert it to what we had before and revisit this issue later on, when we review a11y for the database activity.