### PR TITLE
MOBILE-3833 DX: Configure default browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "ng": "ng",
-    "start": "ionic serve",
+    "start": "ionic serve --browser=$MOODLE_APP_BROWSER",
     "build": "ionic build",
     "build:prod": "NODE_ENV=production ionic build --prod",
     "build:test": "NODE_ENV=testing ionic build",


### PR DESCRIPTION
As documented in https://docs.moodle.org/dev/Using_the_Moodle_App_in_a_browser#Configuring_the_default_browser