### PR TITLE
MOBILE-3833 DX: Configure `serve:test` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ionic serve --browser=$MOODLE_APP_BROWSER",
+    "serve:test": "NODE_ENV=testing ionic serve --no-open",
     "build": "ionic build",
     "build:prod": "NODE_ENV=production ionic build --prod",
     "build:test": "NODE_ENV=testing ionic build",


### PR DESCRIPTION
Added this script in order to go in line with the documentation at https://docs.moodle.org/dev/Acceptance_testing_for_the_Moodle_App