### PR TITLE
MOBILE-3833: Fix JIT for site plugins

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -66,6 +66,20 @@
                 }
               ]
             },
+            "testing": {
+              "optimization": {
+                "scripts": false,
+                "styles": true
+              },
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true
+            },
             "ci": {
               "progress": false
             }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "serve:test": "NODE_ENV=testing ionic serve --no-open",
     "build": "ionic build",
     "build:prod": "NODE_ENV=production ionic build --prod",
-    "build:test": "NODE_ENV=testing ionic build",
+    "build:test": "NODE_ENV=testing ionic build --configuration=testing",
     "dev:android": "ionic cordova run android --livereload",
     "dev:ios": "ionic cordova run ios",
     "prod:android": "NODE_ENV=production ionic cordova run android --prod",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = config => {
                 compress: {
                     toplevel: true,
                     pure_getters: true,
+                    side_effects: false,
                 },
                 keep_classnames: true,
                 keep_fnames: true,


### PR DESCRIPTION
I configured optimization in the testing build in order to make it behave as similar as possible to production. Before this change, site plugins were broken but Behat tests were passing. This should be used mostly in CI anyways, developers running tests locally should be using the `serve:test` command instead.