### PR TITLE
MOBILE-3833 core: Fix collisions in link handlers

### DIFF
--- a/src/addons/badges/services/handlers/badge-link.ts
+++ b/src/addons/badges/services/handlers/badge-link.ts
@@ -27,7 +27,7 @@ import { AddonBadges } from '../badges';
 export class AddonBadgesBadgeLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'AddonBadgesBadgeLinkHandler';
-    pattern = /\/badges\/badge\.php.*([?&]hash=)/;
+    pattern = /^\/badges\/badge\.php.*([?&]hash=)/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/badges/services/handlers/mybadges-link.ts
+++ b/src/addons/badges/services/handlers/mybadges-link.ts
@@ -27,7 +27,7 @@ export class AddonBadgesMyBadgesLinkHandlerService extends CoreContentLinksHandl
 
     name = 'AddonBadgesMyBadgesLinkHandler';
     featureName = 'CoreUserDelegate_AddonBadges';
-    pattern = /\/badges\/mybadges\.php/;
+    pattern = /^\/badges\/mybadges\.php/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/blog/services/handlers/index-link.ts
+++ b/src/addons/blog/services/handlers/index-link.ts
@@ -28,7 +28,7 @@ export class AddonBlogIndexLinkHandlerService extends CoreContentLinksHandlerBas
 
     name = 'AddonBlogIndexLinkHandler';
     featureName = 'CoreUserDelegate_AddonBlog:blogs';
-    pattern = /\/blog\/index\.php/;
+    pattern = /^\/blog\/index\.php/;
 
     /**
      * @inheritdoc

--- a/src/addons/calendar/services/handlers/view-link.ts
+++ b/src/addons/calendar/services/handlers/view-link.ts
@@ -30,7 +30,7 @@ const SUPPORTED_VIEWS = ['month', 'mini', 'minithree', 'day', 'upcoming', 'upcom
 export class AddonCalendarViewLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'AddonCalendarViewLinkHandler';
-    pattern = /\/calendar\/view\.php/;
+    pattern = /^\/calendar\/view\.php/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/messages/services/handlers/contact-request-link.ts
+++ b/src/addons/messages/services/handlers/contact-request-link.ts
@@ -26,7 +26,7 @@ import { AddonMessages } from '../messages';
 export class AddonMessagesContactRequestLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'AddonMessagesContactRequestLinkHandler';
-    pattern = /\/message\/pendingcontactrequests\.php/;
+    pattern = /^\/message\/pendingcontactrequests\.php/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/messages/services/handlers/discussion-link.ts
+++ b/src/addons/messages/services/handlers/discussion-link.ts
@@ -29,7 +29,7 @@ import { AddonMessages } from '../messages';
 export class AddonMessagesDiscussionLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'AddonMessagesDiscussionLinkHandler';
-    pattern = /\/message\/index\.php.*([?&](id|user1|user2)=\d+)/;
+    pattern = /^\/message\/index\.php.*([?&](id|user1|user2)=\d+)/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/messages/services/handlers/index-link.ts
+++ b/src/addons/messages/services/handlers/index-link.ts
@@ -28,7 +28,7 @@ import { AddonMessagesMainMenuHandlerService } from './mainmenu';
 export class AddonMessagesIndexLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'AddonMessagesIndexLinkHandler';
-    pattern = /\/message\/index\.php((?![?&](id|user1|user2)=\d+).)*$/;
+    pattern = /^\/message\/index\.php((?![?&](id|user1|user2)=\d+).)*$/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/mod/data/services/handlers/approve-link.ts
+++ b/src/addons/mod/data/services/handlers/approve-link.ts
@@ -28,7 +28,7 @@ export class AddonModDataApproveLinkHandlerService extends CoreContentLinksHandl
 
     name = 'AddonModDataApproveLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModData';
-    pattern = /\/mod\/data\/view\.php.*([?&](d|approve|disapprove)=\d+)/;
+    pattern = /^\/mod\/data\/view\.php.*([?&](d|approve|disapprove)=\d+)/;
     priority = 50; // Higher priority than the default link handler for view.php.
 
     /**

--- a/src/addons/mod/data/services/handlers/delete-link.ts
+++ b/src/addons/mod/data/services/handlers/delete-link.ts
@@ -28,7 +28,7 @@ export class AddonModDataDeleteLinkHandlerService extends CoreContentLinksHandle
 
     name = 'AddonModDataDeleteLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModData';
-    pattern = /\/mod\/data\/view\.php.*([?&](d|delete)=\d+)/;
+    pattern = /^\/mod\/data\/view\.php.*([?&](d|delete)=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/data/services/handlers/edit-link.ts
+++ b/src/addons/mod/data/services/handlers/edit-link.ts
@@ -32,7 +32,7 @@ export class AddonModDataEditLinkHandlerService extends CoreContentLinksHandlerB
 
     name = 'AddonModDataEditLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModData';
-    pattern = /\/mod\/data\/edit\.php.*([?&](d|rid)=\d+)/;
+    pattern = /^\/mod\/data\/edit\.php.*([?&](d|rid)=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/data/services/handlers/show-link.ts
+++ b/src/addons/mod/data/services/handlers/show-link.ts
@@ -32,7 +32,7 @@ export class AddonModDataShowLinkHandlerService extends CoreContentLinksHandlerB
 
     name = 'AddonModDataShowLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModData';
-    pattern = /\/mod\/data\/view\.php.*([?&](d|rid|page|group|mode)=\d+)/;
+    pattern = /^\/mod\/data\/view\.php.*([?&](d|rid|page|group|mode)=\d+)/;
     priority = 50; // Higher priority than the default link handler for view.php.
 
     /**

--- a/src/addons/mod/feedback/services/handlers/analysis-link.ts
+++ b/src/addons/mod/feedback/services/handlers/analysis-link.ts
@@ -30,7 +30,7 @@ export class AddonModFeedbackAnalysisLinkHandlerService extends CoreContentLinks
 
     name = 'AddonModFeedbackAnalysisLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModFeedback';
-    pattern = /\/mod\/feedback\/analysis\.php.*([&?]id=\d+)/;
+    pattern = /^\/mod\/feedback\/analysis\.php.*([&?]id=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/feedback/services/handlers/complete-link.ts
+++ b/src/addons/mod/feedback/services/handlers/complete-link.ts
@@ -31,7 +31,7 @@ export class AddonModFeedbackCompleteLinkHandlerService extends CoreContentLinks
 
     name = 'AddonModFeedbackCompleteLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModFeedback';
-    pattern = /\/mod\/feedback\/complete\.php.*([?&](id|gopage)=\d+)/;
+    pattern = /^\/mod\/feedback\/complete\.php.*([?&](id|gopage)=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/feedback/services/handlers/print-link.ts
+++ b/src/addons/mod/feedback/services/handlers/print-link.ts
@@ -31,7 +31,7 @@ export class AddonModFeedbackPrintLinkHandlerService extends CoreContentLinksHan
 
     name = 'AddonModFeedbackPrintLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModFeedback';
-    pattern = /\/mod\/feedback\/print\.php.*([?&](id)=\d+)/;
+    pattern = /^\/mod\/feedback\/print\.php.*([?&](id)=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/feedback/services/handlers/show-entries-link.ts
+++ b/src/addons/mod/feedback/services/handlers/show-entries-link.ts
@@ -27,7 +27,7 @@ export class AddonModFeedbackShowEntriesLinkHandlerService extends CoreContentLi
 
     name = 'AddonModFeedbackShowEntriesLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModFeedback';
-    pattern = /\/mod\/feedback\/show_entries\.php.*([?&](id|showcompleted)=\d+)/;
+    pattern = /^\/mod\/feedback\/show_entries\.php.*([?&](id|showcompleted)=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/feedback/services/handlers/show-non-respondents-link.ts
+++ b/src/addons/mod/feedback/services/handlers/show-non-respondents-link.ts
@@ -30,7 +30,7 @@ export class AddonModFeedbackShowNonRespondentsLinkHandlerService extends CoreCo
 
     name = 'AddonModFeedbackShowNonRespondentsLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModFeedback';
-    pattern = /\/mod\/feedback\/show_nonrespondents\.php.*([?&](id)=\d+)/;
+    pattern = /^\/mod\/feedback\/show_nonrespondents\.php.*([?&](id)=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/forum/services/handlers/discussion-link.ts
+++ b/src/addons/mod/forum/services/handlers/discussion-link.ts
@@ -28,7 +28,7 @@ export class AddonModForumDiscussionLinkHandlerService extends CoreContentLinksH
 
     name = 'AddonModForumDiscussionLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModForum';
-    pattern = /\/mod\/forum\/discuss\.php.*([&?]d=\d+)/;
+    pattern = /^\/mod\/forum\/discuss\.php.*([&?]d=\d+)/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/mod/forum/services/handlers/post-link.ts
+++ b/src/addons/mod/forum/services/handlers/post-link.ts
@@ -32,7 +32,7 @@ export class AddonModForumPostLinkHandlerService extends CoreContentLinksHandler
 
     name = 'AddonModForumPostLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModForum';
-    pattern = /\/mod\/forum\/post\.php.*([?&](forum)=\d+)/;
+    pattern = /^\/mod\/forum\/post\.php.*([?&](forum)=\d+)/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/mod/glossary/services/handlers/edit-link.ts
+++ b/src/addons/mod/glossary/services/handlers/edit-link.ts
@@ -32,7 +32,7 @@ export class AddonModGlossaryEditLinkHandlerService extends CoreContentLinksHand
 
     name = 'AddonModGlossaryEditLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModGlossary';
-    pattern = /\/mod\/glossary\/edit\.php.*([?&](cmid)=\d+)/;
+    pattern = /^\/mod\/glossary\/edit\.php.*([?&](cmid)=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/glossary/services/handlers/entry-link.ts
+++ b/src/addons/mod/glossary/services/handlers/entry-link.ts
@@ -31,7 +31,7 @@ export class AddonModGlossaryEntryLinkHandlerService extends CoreContentLinksHan
 
     name = 'AddonModGlossaryEntryLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModGlossary';
-    pattern = /\/mod\/glossary\/(showentry|view)\.php.*([&?](eid|g|mode|hook)=\d+)/;
+    pattern = /^\/mod\/glossary\/(showentry|view)\.php.*([&?](eid|g|mode|hook)=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/h5pactivity/services/handlers/report-link.ts
+++ b/src/addons/mod/h5pactivity/services/handlers/report-link.ts
@@ -33,7 +33,7 @@ export class AddonModH5PActivityReportLinkHandlerService extends CoreContentLink
 
     name = 'AddonModH5PActivityReportLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModH5PActivity';
-    pattern = /\/mod\/h5pactivity\/report\.php.*([&?]a=\d+)/;
+    pattern = /^\/mod\/h5pactivity\/report\.php.*([&?]a=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/lesson/services/handlers/report-link.ts
+++ b/src/addons/mod/lesson/services/handlers/report-link.ts
@@ -31,7 +31,7 @@ export class AddonModLessonReportLinkHandlerService extends CoreContentLinksHand
 
     name = 'AddonModLessonReportLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModLesson';
-    pattern = /\/mod\/lesson\/report\.php.*([&?]id=\d+)/;
+    pattern = /^\/mod\/lesson\/report\.php.*([&?]id=\d+)/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/mod/quiz/services/handlers/review-link.ts
+++ b/src/addons/mod/quiz/services/handlers/review-link.ts
@@ -26,7 +26,7 @@ export class AddonModQuizReviewLinkHandlerService extends CoreContentLinksHandle
 
     name = 'AddonModQuizReviewLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModQuiz';
-    pattern = /\/mod\/quiz\/review\.php.*([&?]attempt=\d+)/;
+    pattern = /^\/mod\/quiz\/review\.php.*([&?]attempt=\d+)/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/addons/mod/wiki/services/handlers/create-link.ts
+++ b/src/addons/mod/wiki/services/handlers/create-link.ts
@@ -33,7 +33,7 @@ export class AddonModWikiCreateLinkHandlerService extends CoreContentLinksHandle
 
     name = 'AddonModWikiCreateLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModWiki';
-    pattern = /\/mod\/wiki\/create\.php.*([&?]swid=\d+)/;
+    pattern = /^\/mod\/wiki\/create\.php.*([&?]swid=\d+)/;
 
     /**
      * Check if the current view is a wiki page of the same wiki.

--- a/src/addons/mod/wiki/services/handlers/edit-link.ts
+++ b/src/addons/mod/wiki/services/handlers/edit-link.ts
@@ -31,7 +31,7 @@ export class AddonModWikiEditLinkHandlerService extends CoreContentLinksHandlerB
 
     name = 'AddonModWikiEditLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModWiki';
-    pattern = /\/mod\/wiki\/edit\.php.*([&?]pageid=\d+)/;
+    pattern = /^\/mod\/wiki\/edit\.php.*([&?]pageid=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/mod/wiki/services/handlers/page-or-map-link.ts
+++ b/src/addons/mod/wiki/services/handlers/page-or-map-link.ts
@@ -32,7 +32,7 @@ export class AddonModWikiPageOrMapLinkHandlerService extends CoreContentLinksHan
 
     name = 'AddonModWikiPageOrMapLinkHandler';
     featureName = 'CoreCourseModuleDelegate_AddonModWiki';
-    pattern = /\/mod\/wiki\/(view|map)\.php.*([&?]pageid=\d+)/;
+    pattern = /^\/mod\/wiki\/(view|map)\.php.*([&?]pageid=\d+)/;
 
     /**
      * @inheritdoc

--- a/src/addons/notifications/services/handlers/notifications-link.ts
+++ b/src/addons/notifications/services/handlers/notifications-link.ts
@@ -27,7 +27,7 @@ import { AddonNotificationsMainMenuHandlerService } from './mainmenu';
 export class AddonNotificationsLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'AddonNotificationsLinkHandler';
-    pattern = /\/message\/output\/popup\/notifications\.php/;
+    pattern = /^\/message\/output\/popup\/notifications\.php/;
     featureName = 'CoreMainMenuDelegate_AddonNotifications';
 
     /**

--- a/src/addons/notifications/services/handlers/preferences-link.ts
+++ b/src/addons/notifications/services/handlers/preferences-link.ts
@@ -28,7 +28,7 @@ import { AddonNotificationsSettingsHandlerService } from './settings';
 export class AddonNotificationsPreferencesLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'AddonNotificationsPreferencesLinkHandler';
-    pattern = /\/message\/notificationpreferences\.php/;
+    pattern = /^\/message\/notificationpreferences\.php/;
     checkAllUsers = true;
     featureName = 'CoreMainMenuDelegate_AddonNotifications';
 

--- a/src/addons/report/insights/services/handlers/action-link.ts
+++ b/src/addons/report/insights/services/handlers/action-link.ts
@@ -38,7 +38,7 @@ const BULK_ACTIONS = {
 export class AddonReportInsightsActionLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'AddonReportInsightsActionLinkHandler';
-    pattern = /\/report\/insights\/action\.php/;
+    pattern = /^\/report\/insights\/action\.php/;
 
     /**
      * @inheritdoc

--- a/src/core/features/contentlinks/classes/module-grade-handler.ts
+++ b/src/core/features/contentlinks/classes/module-grade-handler.ts
@@ -47,7 +47,7 @@ export class CoreContentLinksModuleGradeHandler extends CoreContentLinksHandlerB
         super();
 
         // Match the grade.php URL with an id param.
-        this.pattern = new RegExp('/mod/' + modName + '/grade.php.*([&?]id=\\d+)');
+        this.pattern = new RegExp('^/mod/' + modName + '/grade.php.*([&?]id=\\d+)');
         this.featureName = 'CoreCourseModuleDelegate_' + addon;
     }
 

--- a/src/core/features/contentlinks/classes/module-index-handler.ts
+++ b/src/core/features/contentlinks/classes/module-index-handler.ts
@@ -43,11 +43,11 @@ export class CoreContentLinksModuleIndexHandler extends CoreContentLinksHandlerB
     ) {
         super();
 
+        // Match the view.php URL with an id or instance id param.
         const pattern = instanceIdParam ?
-            '/mod/' + modName + '/view.php.*([&?](' + instanceIdParam + '|id)=\\d+)' :
-            '/mod/' + modName + '/view.php.*([&?]id=\\d+)';
+            '^/mod/' + modName + '/view.php.*([&?](' + instanceIdParam + '|id)=\\d+)' :
+            '^/mod/' + modName + '/view.php.*([&?]id=\\d+)';
 
-        // Match the view.php URL with an id param.
         this.pattern = new RegExp(pattern);
         this.featureName = 'CoreCourseModuleDelegate_' + addon;
     }

--- a/src/core/features/contentlinks/classes/module-list-handler.ts
+++ b/src/core/features/contentlinks/classes/module-list-handler.ts
@@ -40,8 +40,8 @@ export class CoreContentLinksModuleListHandler extends CoreContentLinksHandlerBa
     ) {
         super();
 
-        // Match the view.php URL with an id param.
-        this.pattern = new RegExp('/mod/' + modName + '/index.php.*([&?]id=\\d+)');
+        // Match the index.php URL with an id param.
+        this.pattern = new RegExp('^/mod/' + modName + '/index.php.*([&?]id=\\d+)');
         this.featureName = 'CoreCourseModuleDelegate_' + addon;
     }
 

--- a/src/core/features/contentlinks/services/contentlinks-delegate.ts
+++ b/src/core/features/contentlinks/services/contentlinks-delegate.ts
@@ -18,6 +18,7 @@ import { CoreSites } from '@services/sites';
 import { CoreUrlUtils } from '@services/utils/url';
 import { CoreUtils } from '@services/utils/utils';
 import { makeSingleton } from '@singletons';
+import { CoreText } from '@singletons/text';
 
 /**
  * Interface that all handlers must implement.
@@ -49,7 +50,7 @@ export interface CoreContentLinksHandler {
      * Get the list of actions for a link (url).
      *
      * @param siteIds List of sites the URL belongs to.
-     * @param url The URL to treat.
+     * @param url The URL to treat.  It's a relative URL, it won't include the site URL.
      * @param params The params of the URL. E.g. 'mysite.com?id=1' -> {id: 1}
      * @param courseId Course ID related to the URL. Optional but recommended.
      * @param data Extra data to handle the URL.
@@ -66,7 +67,7 @@ export interface CoreContentLinksHandler {
     /**
      * Check if a URL is handled by this handler.
      *
-     * @param url The URL to check.
+     * @param url The URL to check. It's a relative URL, it won't include the site URL.
      * @return Whether the URL is handled by this handler
      */
     handles(url: string): boolean;
@@ -84,7 +85,7 @@ export interface CoreContentLinksHandler {
      * If not defined, defaults to true.
      *
      * @param siteId The site ID.
-     * @param url The URL to treat.
+     * @param url The URL to treat.  It's a relative URL, it won't include the site URL.
      * @param params The params of the URL. E.g. 'mysite.com?id=1' -> {id: 1}
      * @param courseId Course ID related to the URL. Optional but recommended.
      * @return Whether the handler is enabled for the URL and site.
@@ -163,15 +164,24 @@ export class CoreContentLinksDelegateService {
 
         // Get the list of sites the URL belongs to.
         const siteIds = await CoreSites.getSiteIdsFromUrl(url, true, username);
+        if (!siteIds.length) {
+            // No sites, no actions.
+            return [];
+        }
+
+        const site = await CoreSites.getSite(siteIds[0]);
+
         const linkActions: CoreContentLinksHandlerActions[] = [];
         const promises: Promise<void>[] = [];
         const params = CoreUrlUtils.extractUrlParams(url);
+        const relativeUrl = CoreText.addStartingSlash(url.replace(site.getURL(), ''));
+
         for (const name in this.handlers) {
             const handler = this.handlers[name];
             const checkAll = handler.checkAllUsers;
-            const isEnabledFn = this.isHandlerEnabled.bind(this, handler, url, params, courseId);
+            const isEnabledFn = this.isHandlerEnabled.bind(this, handler, relativeUrl, params, courseId);
 
-            if (!handler.handles(url)) {
+            if (!handler.handles(relativeUrl)) {
                 // Invalid handler or it doesn't handle the URL. Stop.
                 continue;
             }
@@ -183,7 +193,7 @@ export class CoreContentLinksDelegateService {
                     return;
                 }
 
-                const actions = await handler.getActions(siteIds, url, params, courseId, data);
+                const actions = await handler.getActions(siteIds, relativeUrl, params, courseId, data);
 
                 if (actions && actions.length) {
                     // Set default values if any value isn't supplied.
@@ -262,7 +272,7 @@ export class CoreContentLinksDelegateService {
      * Check if a handler is enabled for a certain site and URL.
      *
      * @param handler Handler to check.
-     * @param url The URL to check.
+     * @param url The URL to check.  It's a relative URL, it won't include the site URL.
      * @param params The params of the URL
      * @param courseId Course ID the URL belongs to (can be undefined).
      * @param siteId The site ID to check.

--- a/src/core/features/courses/services/handlers/course-link.ts
+++ b/src/core/features/courses/services/handlers/course-link.ts
@@ -35,7 +35,7 @@ import { CoreIonLoadingElement } from '@classes/ion-loading';
 export class CoreCoursesCourseLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'CoreCoursesCourseLinkHandler';
-    pattern = /((\/enrol\/index\.php)|(\/course\/enrol\.php)|(\/course\/view\.php)).*([?&]id=\d+)/;
+    pattern = /((^\/enrol\/index\.php)|(^\/course\/enrol\.php)|(^\/course\/view\.php)).*([?&]id=\d+)/;
 
     protected waitStart = 0;
     protected logger: CoreLogger;

--- a/src/core/features/courses/services/handlers/courses-index-link.ts
+++ b/src/core/features/courses/services/handlers/courses-index-link.ts
@@ -28,7 +28,7 @@ export class CoreCoursesIndexLinkHandlerService extends CoreContentLinksHandlerB
 
     name = 'CoreCoursesIndexLinkHandler';
     featureName = 'CoreMainMenuDelegate_CoreCourses';
-    pattern = /\/course\/?(index\.php.*)?$/;
+    pattern = /^\/course\/?(index\.php.*)?$/;
 
     /**
      * @inheritdoc

--- a/src/core/features/courses/services/handlers/dashboard-link.ts
+++ b/src/core/features/courses/services/handlers/dashboard-link.ts
@@ -27,7 +27,7 @@ import { CoreDashboardHomeHandler, CoreDashboardHomeHandlerService } from './das
 export class CoreCoursesDashboardLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'CoreCoursesDashboardLinkHandler';
-    pattern = /\/my\/?$/;
+    pattern = /^\/my\/?$/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/core/features/grades/services/handlers/overview-link.ts
+++ b/src/core/features/grades/services/handlers/overview-link.ts
@@ -27,7 +27,7 @@ import { GRADES_PAGE_NAME } from '../grades-helper';
 export class CoreGradesOverviewLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'CoreGradesOverviewLinkHandler';
-    pattern = /\/grade\/report\/overview\/index.php/;
+    pattern = /^\/grade\/report\/overview\/index.php/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/core/features/grades/services/handlers/report-link.ts
+++ b/src/core/features/grades/services/handlers/report-link.ts
@@ -27,7 +27,7 @@ import { makeSingleton } from '@singletons';
 export class CoreGradesReportLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'CoreGradesReportLinkHandler';
-    pattern = /\/grade\/report(\/user)?\/index.php/;
+    pattern = /^\/grade\/report(\/user)?\/index.php/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/core/features/grades/services/handlers/user-link.ts
+++ b/src/core/features/grades/services/handlers/user-link.ts
@@ -27,7 +27,7 @@ import { makeSingleton } from '@singletons';
 export class CoreGradesUserLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'CoreGradesUserLinkHandler';
-    pattern = /\/course\/user\.php.*[?&]mode=grade/;
+    pattern = /^\/course\/user\.php.*[?&]mode=grade/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/core/features/sitehome/services/handlers/index-link.ts
+++ b/src/core/features/sitehome/services/handlers/index-link.ts
@@ -31,7 +31,7 @@ export class CoreSiteHomeIndexLinkHandlerService extends CoreContentLinksHandler
 
     name = 'CoreSiteHomeIndexLinkHandler';
     featureName = 'CoreMainMenuDelegate_CoreSiteHome';
-    pattern = /\/course\/view\.php.*([?&]id=\d+)|\/index\.php(\?redirect=0)?/;
+    pattern = /^\/course\/view\.php.*([?&]id=\d+)|^\/index\.php(\?redirect=0)?/;
 
     /**
      * @inheritdoc

--- a/src/core/features/tag/services/handlers/index-link.ts
+++ b/src/core/features/tag/services/handlers/index-link.ts
@@ -27,7 +27,7 @@ import { CoreTag } from '../tag';
 export class CoreTagIndexLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'CoreTagIndexLinkHandler';
-    pattern = /\/tag\/index\.php/;
+    pattern = /^\/tag\/index\.php/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/core/features/tag/services/handlers/search-link.ts
+++ b/src/core/features/tag/services/handlers/search-link.ts
@@ -27,7 +27,7 @@ import { CoreTag } from '../tag';
 export class CoreTagSearchLinkHandlerService extends CoreContentLinksHandlerBase {
 
     name = 'CoreTagSearchLinkHandler';
-    pattern = /\/tag\/search\.php/;
+    pattern = /^\/tag\/search\.php/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/core/features/user/services/handlers/profile-link.ts
+++ b/src/core/features/user/services/handlers/profile-link.ts
@@ -27,7 +27,7 @@ export class CoreUserProfileLinkHandlerService extends CoreContentLinksHandlerBa
 
     name = 'CoreUserProfileLinkHandler';
     // Match user/view.php and user/profile.php but NOT grade/report/user/.
-    pattern = /((\/user\/view\.php)|(\/user\/profile\.php)).*([?&]id=\d+)/;
+    pattern = /((^\/user\/view\.php)|(^\/user\/profile\.php)).*([?&]id=\d+)/;
 
     /**
      * Get the list of actions for a link (url).

--- a/src/core/services/sites.ts
+++ b/src/core/services/sites.ts
@@ -1484,7 +1484,7 @@ export class CoreSitesProvider {
     async getSiteIdsFromUrl(url: string, prioritize?: boolean, username?: string): Promise<string[]> {
         // If prioritize is true, check current site first.
         if (prioritize && this.currentSite && this.currentSite.containsUrl(url)) {
-            if (!username || this.currentSite?.getInfo()?.username == username) {
+            if (!username || this.currentSite?.getInfo()?.username === username) {
                 return [this.currentSite.getId()];
             }
         }
@@ -1508,21 +1508,18 @@ export class CoreSitesProvider {
         try {
             const siteEntries = await this.sitesTable.getMany();
             const ids: string[] = [];
-            const promises: Promise<unknown>[] = [];
 
-            siteEntries.forEach((site) => {
+            await Promise.all(siteEntries.map(async (site) => {
                 if (!this.sites[site.id]) {
-                    promises.push(this.addSiteFromSiteListEntry(site));
+                    await this.addSiteFromSiteListEntry(site);
                 }
 
                 if (this.sites[site.id].containsUrl(url)) {
-                    if (!username || this.sites[site.id].getInfo()?.username == username) {
+                    if (!username || this.sites[site.id].getInfo()?.username === username) {
                         ids.push(site.id);
                     }
                 }
-            });
-
-            await Promise.all(promises);
+            }));
 
             return ids;
         } catch {

--- a/src/core/singletons/text.ts
+++ b/src/core/singletons/text.ts
@@ -23,6 +23,20 @@ export class CoreText {
     }
 
     /**
+     * Add starting slash to a string if needed.
+     *
+     * @param text Text to treat.
+     * @return Treated text.
+     */
+    static addStartingSlash(text = ''): string {
+        if (text[0] === '/') {
+            return text;
+        }
+
+        return '/' + text;
+    }
+
+    /**
      * Remove ending slash from a path or URL.
      *
      * @param text Text to treat.

--- a/upgrade.txt
+++ b/upgrade.txt
@@ -24,6 +24,7 @@ information provided here is intended especially for developers.
 - contextMenuPrefetch and fillContextMenu have been removed from CoreCourseHelper.
 - The variable "loaded" in CoreCourseModuleMainResourceComponent has been changed to "showLoading" to reflect its purpose better.
 - The function getCurrentSection of course formats can now return a forceSelected boolean along with the section (defaults to false if not returned).
+- The link handlers functions (CoreContentLinksHandler) will now always receive a relative URL instead of an absolute URL. It's now recommended to use "^" in your regular expressions to avoid false positives.
 
 
 


### PR DESCRIPTION
The /admin handlers haven't been modified because that folder can be moved to somewhere else in some Moodle versions