### PR TITLE
MOBILE-4081 external-content: Set attribute for untreated urls

### DIFF
--- a/src/core/directives/external-content.ts
+++ b/src/core/directives/external-content.ts
@@ -210,6 +210,9 @@ export class CoreExternalContentDirective implements AfterViewInit, OnChanges, O
             if (tagName === 'SOURCE') {
                 // Restoring original src.
                 this.addSource(url);
+            } else if (url && !this.element.getAttribute(targetAttr)) {
+                // By default, Angular inputs aren't added as DOM attributes. Add it now.
+                this.element.setAttribute(targetAttr, url);
             }
 
             throw new CoreError('Non-downloadable URL');


### PR DESCRIPTION
This fixes an issue when rendering images using directly the local URL (e.g. in image viewer)