### PR TITLE
MOBILE-4065 a11y: Hide pages under user tours

### DIFF
--- a/src/core/features/block/components/side-blocks-tour/side-blocks-tour.html
+++ b/src/core/features/block/components/side-blocks-tour/side-blocks-tour.html
@@ -1,4 +1,4 @@
-<h2>{{ 'core.block.tour_navigation_dashboard_title' | translate }}</h2>
+<h1>{{ 'core.block.tour_navigation_dashboard_title' | translate }}</h1>
 <p>{{ 'core.block.tour_navigation_dashboard_content' | translate }}</p>
 <ion-button (click)="dismiss()" expand="block">
     {{ 'core.endonesteptour' | translate }}

--- a/src/core/features/course/components/course-index-tour/course-index-tour.html
+++ b/src/core/features/course/components/course-index-tour/course-index-tour.html
@@ -1,4 +1,4 @@
-<h2>{{ 'core.course.tour_navigation_course_index_student_title' | translate }}</h2>
+<h1>{{ 'core.course.tour_navigation_course_index_student_title' | translate }}</h1>
 <p>{{ 'core.course.tour_navigation_course_index_student_content' | translate }}</p>
 <ion-button (click)="dismiss()" expand="block">
     {{ 'core.endonesteptour' | translate }}

--- a/src/core/features/mainmenu/components/user-menu-tour/user-menu-tour.html
+++ b/src/core/features/mainmenu/components/user-menu-tour/user-menu-tour.html
@@ -1,4 +1,4 @@
-<h2>{{ 'core.mainmenu.usermenutourtitle' | translate }}</h2>
+<h1>{{ 'core.mainmenu.usermenutourtitle' | translate }}</h1>
 <p>{{ 'core.mainmenu.usermenutourdescription' | translate }}</p>
 <ion-button (click)="dismiss()" expand="block">
     {{ 'core.endonesteptour' | translate }}

--- a/src/core/features/usertours/services/user-tours.ts
+++ b/src/core/features/usertours/services/user-tours.ts
@@ -115,12 +115,15 @@ export class CoreUserToursService {
         await CoreUtils.wait(delay ?? 200);
 
         const container = document.querySelector('ion-app') ?? document.body;
+        const viewContainer = container.querySelector('ion-router-outlet, ion-nav, #ion-view-container-root');
         const element = await AngularFrameworkDelegate.attachViewToDom(
             container,
             CoreUserToursUserTourComponent,
             { ...componentOptions, container },
         );
         const tour = CoreDirectivesRegistry.require(element, CoreUserToursUserTourComponent);
+
+        viewContainer?.setAttribute('aria-hidden', 'true');
 
         return this.startTour(tour, options.watch ?? (options as CoreUserToursFocusedOptions).focus);
     }
@@ -132,6 +135,15 @@ export class CoreUserToursService {
      */
     async dismiss(acknowledge: boolean = true): Promise<void> {
         await this.getForegroundTour()?.dismiss(acknowledge);
+
+        if (this.hasVisibleTour()) {
+            return;
+        }
+
+        const container = document.querySelector('ion-app') ?? document.body;
+        const viewContainer = container.querySelector('ion-router-outlet, ion-nav, #ion-view-container-root');
+
+        viewContainer?.removeAttribute('aria-hidden');
     }
 
     /**
@@ -239,6 +251,15 @@ export class CoreUserToursService {
      */
     protected getForegroundTour(): CoreUserToursUserTourComponent | undefined {
         return this.tours.find(({ visible }) => visible)?.component;
+    }
+
+    /**
+     * Check whether any tour is visible.
+     *
+     * @returns Whether any tour is visible.
+     */
+    protected hasVisibleTour(): boolean {
+        return this.tours.some(({ visible }) => visible);
     }
 
     /**


### PR DESCRIPTION
Following the same strategy as Ionic's built-in overlays https://github.com/ionic-team/ionic-framework/blob/1b30fc97d33e761866b4bcf7518efcdeb753032d/core/src/utils/overlays.ts#L388..L401