### PR TITLE
MOBILE-4281 assign: Limit marking workflow behats to 4.0+

### DIFF
--- a/src/addons/mod/assign/tests/behat/marking_workflow.feature
+++ b/src/addons/mod/assign/tests/behat/marking_workflow.feature
@@ -1,4 +1,4 @@
-@mod @mod_assign @app @javascript
+@mod @mod_assign @app @javascript @lms_from4.0
 Feature: Test marking workflow in assignment activity in app
 
   Background:


### PR DESCRIPTION
The reason is that the steps to mark submissions in LMS don't work in older sites, they need to be different