### PR TITLE
MOBILE-4215 cordova: Use fork of cordova-plugin-camera

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5405,6 +5405,11 @@
         }
       }
     },
+    "@moodlehq/cordova-plugin-camera": {
+      "version": "6.0.0-moodle.1",
+      "resolved": "https://registry.npmjs.org/@moodlehq/cordova-plugin-camera/-/cordova-plugin-camera-6.0.0-moodle.1.tgz",
+      "integrity": "sha512-j/s6DjP5uG5Fb6LKGAIUn+jGXwsXWP1JF+GmovS6rvs5jTNN8zGvlhwQhkU8aWWMIwd/fVZtV455Jux1u50/LA=="
+    },
     "@moodlehq/cordova-plugin-file-transfer": {
       "version": "1.7.1-moodle.5",
       "resolved": "https://registry.npmjs.org/@moodlehq/cordova-plugin-file-transfer/-/cordova-plugin-file-transfer-1.7.1-moodle.5.tgz",
@@ -20433,11 +20438,6 @@
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/cordova-plugin-badge/-/cordova-plugin-badge-0.8.9.tgz",
       "integrity": "sha512-oVv+z3B7Jgi7/gnE/jvSnjBsBNwZVoLmJYwTUw3nLmp50fnY22H7NWthTachEdle2EljDk8AzvhuDpdf0triIw=="
-    },
-    "cordova-plugin-camera": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-camera/-/cordova-plugin-camera-6.0.0.tgz",
-      "integrity": "sha512-FTFKep8HZI/2HkX+Gc/dUACfZGV9+k9waXlgoEOKXOiPPR/1zBw29Mw+adcz4FQUpdWyAgYDxNiaPUnP0P+H2Q=="
     },
     "cordova-plugin-chooser": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@ionic-native/web-intent": "5.36.0",
     "@ionic-native/zip": "5.36.0",
     "@ionic/angular": "5.9.4",
+    "@moodlehq/cordova-plugin-camera": "6.0.0-moodle.1",
     "@moodlehq/cordova-plugin-file-transfer": "1.7.1-moodle.5",
     "@moodlehq/cordova-plugin-inappbrowser": "5.0.0-moodle.3",
     "@moodlehq/cordova-plugin-intent": "2.2.0-moodle.1",
@@ -95,7 +96,6 @@
     "cordova-plugin-advanced-http": "3.3.1",
     "cordova-plugin-androidx-adapter": "1.1.3",
     "cordova-plugin-badge": "0.8.9",
-    "cordova-plugin-camera": "6.0.0",
     "cordova-plugin-chooser": "1.3.2",
     "cordova-plugin-customurlscheme": "5.0.2",
     "cordova-plugin-device": "2.1.0",
@@ -197,8 +197,7 @@
       },
       "cordova-clipboard": {},
       "cordova-plugin-badge": {},
-      "cordova-plugin-camera": {
-        "ANDROID_SUPPORT_V4_VERSION": "27.+",
+      "@moodlehq/cordova-plugin-camera": {
         "ANDROIDX_CORE_VERSION": "1.6.+"
       },
       "cordova-plugin-chooser": {},


### PR DESCRIPTION
The official plugin doesn't work in Android with API 33