### PR TITLE
MOBILE-4270 core: Fix list items auto-scroll

### DIFF
--- a/src/core/classes/items-management/list-items-manager.ts
+++ b/src/core/classes/items-management/list-items-manager.ts
@@ -40,7 +40,10 @@ export class CoreListItemsManager<
     constructor(source: Source, pageRouteLocator: unknown | ActivatedRoute) {
         super(source);
 
+        const debouncedScrollToCurrentElement = CoreUtils.debounce(() => this.scrollToCurrentElement(), 300);
+
         this.pageRouteLocator = pageRouteLocator;
+        this.addListener({ onSelectedItemUpdated: debouncedScrollToCurrentElement });
     }
 
     get items(): Item[] {
@@ -130,7 +133,6 @@ export class CoreListItemsManager<
         }
 
         await this.navigateToItem(item, { reset: this.resetNavigation() });
-        setTimeout(async () => await this.scrollToCurrentElement(), 100);
     }
 
     /**


### PR DESCRIPTION
The previous implementation was running into some race conditions that caused it to scroll back to the previously selected item sometimes.