### PR TITLE
MOBILE-4048 chat: Log sessions view events

### DIFF
--- a/src/addons/mod/chat/pages/session-messages/session-messages.ts
+++ b/src/addons/mod/chat/pages/session-messages/session-messages.ts
@@ -48,12 +48,17 @@ export class AddonModChatSessionMessagesPage implements OnInit {
     protected logView: () => void;
 
     constructor() {
-        this.logView = CoreTime.once(() => {
+        this.logView = CoreTime.once(async () => {
+            await CoreUtils.ignoreErrors(AddonModChat.logViewSessions(this.cmId, {
+                start: this.sessionStart,
+                end: this.sessionEnd,
+            }));
+
             CoreAnalytics.logEvent({
-                type: CoreAnalyticsEventType.VIEW_ITEM_LIST,
+                type: CoreAnalyticsEventType.VIEW_ITEM,
                 ws: 'mod_chat_view_sessions',
                 name: Translate.instant('addon.mod_chat.messages'),
-                data: { chatid: this.chatId, category: 'chat' },
+                data: { chatid: this.chatId, category: 'chat', start: this.sessionStart, end: this.sessionEnd },
                 url: `/mod/chat/report.php?id=${this.cmId}&start=${this.sessionStart}&end=${this.sessionEnd}`,
             });
         });

--- a/src/addons/mod/chat/pages/sessions/sessions.ts
+++ b/src/addons/mod/chat/pages/sessions/sessions.ts
@@ -24,6 +24,8 @@ import { AddonModChatSessionFormatted, AddonModChatSessionsSource } from '../../
 import { CoreAnalytics, CoreAnalyticsEventType } from '@services/analytics';
 import { CoreTime } from '@singletons/time';
 import { Translate } from '@singletons';
+import { AddonModChat } from '@addons/mod/chat/services/chat';
+import { CoreUtils } from '@services/utils/utils';
 
 /**
  * Page that displays list of chat sessions.
@@ -41,8 +43,10 @@ export class AddonModChatSessionsPage implements OnInit, AfterViewInit, OnDestro
     protected logView: () => void;
 
     constructor() {
-        this.logView = CoreTime.once(() => {
+        this.logView = CoreTime.once(async () => {
             const source = this.sessions.getSource();
+
+            await CoreUtils.ignoreErrors(AddonModChat.logViewSessions(this.sessions.getSource().CM_ID));
 
             CoreAnalytics.logEvent({
                 type: CoreAnalyticsEventType.VIEW_ITEM_LIST,

--- a/src/addons/mod/chat/services/chat.ts
+++ b/src/addons/mod/chat/services/chat.ts
@@ -105,6 +105,32 @@ export class AddonModChatProvider {
     }
 
     /**
+     * Report chat session views.
+     *
+     * @param id Chat instance ID.
+     * @param period Session period if viewing an individual session.
+     * @param period.start Period start.
+     * @param period.end Period end.
+     */
+    async logViewSessions(id: number, period?: { start: number; end: number }): Promise<void> {
+        const params: AddonModChatViewSessionsWSParams = {
+            cmid: id,
+        };
+
+        if (period) {
+            params.start = period.start;
+            params.end = period.end;
+        }
+
+        await CoreCourseLogHelper.log(
+            'mod_chat_view_sessions',
+            params,
+            AddonModChatProvider.COMPONENT,
+            id,
+        );
+    }
+
+    /**
      * Send a message to a chat.
      *
      * @param sessionId Chat sessiond ID.
@@ -476,6 +502,15 @@ export type AddonModChatLoginUserWSResponse = {
  */
 export type AddonModChatViewChatWSParams = {
     chatid: number; // Chat instance id.
+};
+
+/**
+ * Params of mod_chat_view_sessions WS.
+ */
+export type AddonModChatViewSessionsWSParams = {
+    cmid: number; // Course module id.
+    start?: number; // Session start time.
+    end?: number; // Session end time.
 };
 
 /**


### PR DESCRIPTION
This could be integrated already, but it won't work until [MDL-74568](https://tracker.moodle.org/browse/MDL-74568) is integrated in core, so I'm leaving it as a draft until then.