### PR TITLE
MOBILE-4401 wiki: Fix selected subwiki when wiki is empty

### DIFF
--- a/src/core/features/course/tests/behat/basic_usage.feature
+++ b/src/core/features/course/tests/behat/basic_usage.feature
@@ -144,7 +144,6 @@ Feature: Test basic usage of one course in app
 
     When I press the back button in the app
     And I press "Test wiki name" in the app
-    And I press "OK" in the app
     Then the header should be "Test wiki name" in the app
 
     When I press the back button in the app
@@ -199,7 +198,6 @@ Feature: Test basic usage of one course in app
 
     When I press the back button in the app
     And I press "Test wiki name" in the app
-    And I press "OK" in the app
     Then the header should be "Test wiki name" in the app
 
     When I press the back button in the app


### PR DESCRIPTION
This commit avoids a redundant error and also allows the create button to appear if the user has permissions to create the first page