### PR TITLE
MOBILE-3371 search: Remove top results

### DIFF
--- a/src/core/features/search/classes/global-search-results-source.ts
+++ b/src/core/features/search/classes/global-search-results-source.ts
@@ -27,9 +27,6 @@ export class CoreSearchGlobalSearchResultsSource extends CorePaginatedItemsManag
 
     private query: string;
     private filters: CoreSearchGlobalSearchFilters;
-    private pagesLoaded = 0;
-    private totalResults?: number;
-    private topResultsIds?: number[];
 
     constructor(query: string, filters: CoreSearchGlobalSearchFilters) {
         super();
@@ -90,62 +87,10 @@ export class CoreSearchGlobalSearchResultsSource extends CorePaginatedItemsManag
     /**
      * @inheritdoc
      */
-    getPagesLoaded(): number {
-        return this.pagesLoaded;
-    }
-
-    /**
-     * Get total results with the given filter.
-     *
-     * @returns Total results.
-     */
-    getTotalResults(): number | null {
-        return this.totalResults ?? null;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    async reload(): Promise<void> {
-        this.pagesLoaded = 0;
-
-        await super.reload();
-    }
-
-    /**
-     * Reset collection data.
-     */
-    reset(): void {
-        this.pagesLoaded = 0;
-        delete this.totalResults;
-        delete this.topResultsIds;
-
-        super.reset();
-    }
-
-    /**
-     * @inheritdoc
-     */
     protected async loadPageItems(page: number): Promise<{ items: CoreSearchGlobalSearchResult[]; hasMoreItems: boolean }> {
-        this.pagesLoaded++;
-
-        const results: CoreSearchGlobalSearchResult[] = [];
-
-        if (page === 0) {
-            const topResults = await CoreSearchGlobalSearch.getTopResults(this.query, this.filters);
-
-            results.push(...topResults);
-
-            this.topResultsIds = topResults.map(result => result.id);
-        }
-
         const pageResults = await CoreSearchGlobalSearch.getResults(this.query, this.filters, page);
 
-        this.totalResults = pageResults.total;
-
-        results.push(...pageResults.results.filter(result => !this.topResultsIds?.includes(result.id)));
-
-        return { items: results, hasMoreItems: pageResults.canLoadMore };
+        return { items: pageResults.results, hasMoreItems: pageResults.canLoadMore };
     }
 
     /**

--- a/src/core/features/search/services/global-search.ts
+++ b/src/core/features/search/services/global-search.ts
@@ -145,30 +145,6 @@ export class CoreSearchGlobalSearchService {
     }
 
     /**
-     * Get top results.
-     *
-     * @param query Search query.
-     * @param filters Search filters.
-     * @returns Top search results.
-     */
-    async getTopResults(query: string, filters: CoreSearchGlobalSearchFilters): Promise<CoreSearchGlobalSearchResult[]> {
-        if (this.filtersYieldEmptyResults(filters)) {
-            return [];
-        }
-
-        const site = CoreSites.getRequiredCurrentSite();
-        const params: CoreSearchGetTopResultsWSParams = {
-            query,
-            filters: await this.prepareAdvancedWSFilters(filters),
-        };
-        const preSets = CoreSites.getReadingStrategyPreSets(CoreSitesReadingStrategy.PREFER_NETWORK);
-
-        const { results } = await site.read<CoreSearchGetTopResultsWSResponse>('core_search_get_top_results', params, preSets);
-
-        return await Promise.all((results ?? []).map(result => this.formatWSResult(result)));
-    }
-
-    /**
      * Get available search areas.
      *
      * @returns Search areas.
@@ -359,14 +335,6 @@ type CoreSearchViewResultsWSParams = {
 };
 
 /**
- * Params of core_search_get_top_results WS.
- */
-type CoreSearchGetTopResultsWSParams = {
-    query: string; // The search query.
-    filters?: CoreSearchAdvancedWSFilters; // Filters to apply.
-};
-
-/**
  * Search result returned in WS.
  */
 type CoreSearchWSResult = { // Search results.
@@ -443,11 +411,4 @@ type CoreSearchGetSearchAreasListWSResponse = {
 type CoreSearchViewResultsWSResponse = {
     status: boolean; // Status: true if success.
     warnings?: CoreWSExternalWarning[];
-};
-
-/**
- * Data returned by core_search_get_top_results WS.
- */
-type CoreSearchGetTopResultsWSResponse = {
-    results?: CoreSearchWSResult[];
 };


### PR DESCRIPTION
They've been removed because they are not respecting category filters. In the LMS it's the expected behaviour because they use category tabs instead, but that is not correct in the app.