### PR TITLE
MOBILE-3947 behat: Fix close popup step

### DIFF
--- a/src/testing/services/behat-runtime.ts
+++ b/src/testing/services/behat-runtime.ts
@@ -190,10 +190,15 @@ export class TestingBehatRuntimeService {
     closePopup(): string {
         this.log('Action - Close popup');
 
-        const backdrops = Array
-            .from(document.querySelectorAll('ion-popover, ion-modal'))
-            .map(popover => popover.shadowRoot?.querySelector('ion-backdrop'))
-            .filter(backdrop => !!backdrop);
+        const backdrops = [
+            ...Array
+                .from(document.querySelectorAll('ion-popover, ion-modal'))
+                .map(popover => popover.shadowRoot?.querySelector('ion-backdrop'))
+                .filter(backdrop => !!backdrop),
+            ...Array
+                .from(document.querySelectorAll('ion-backdrop'))
+                .filter(backdrop => !!backdrop.offsetParent),
+        ];
 
         if (!backdrops.length) {
             return 'ERROR: Could not find backdrop';


### PR DESCRIPTION
This step was also working for other elements such as ion-alert before upgrading to ionic 7, so we should keep the same behaviour.