### PR TITLE
MOBILE-4350 quiz: Allow navigating from sequential summary

### DIFF
--- a/src/addons/mod/quiz/pages/player/player.ts
+++ b/src/addons/mod/quiz/pages/player/player.ts
@@ -271,9 +271,12 @@ export class AddonModQuizPlayerPage implements OnInit, OnDestroy, CanLeave {
             await this.scrollToQuestion(slot);
 
             return;
-        } else if ((page == this.attempt.currentpage && !this.showSummary) || (fromModal && this.isSequential && page != -1)) {
+        } else if (
+            (page == this.attempt.currentpage && !this.showSummary) ||
+            (fromModal && this.isSequential && page != this.attempt.currentpage)
+        ) {
             // If the user is navigating to the current page we do nothing.
-            // Also, in sequential quizzes we don't allow navigating using the modal except for finishing the quiz (summary).
+            // Also, in sequential quizzes we can only navigate to the current page.
             return;
         } else if (page === -1 && this.showSummary) {
             // Summary already shown.


### PR DESCRIPTION
This is consistent with the LMS which has a "return to attempt" button. It also fixes the behaviour that users would expect, given that the buttons in the side navigation for the current page are not disabled in the summary.