### PR TITLE
MOBILE-4569 grades: Remove actions menu

### DIFF
--- a/src/core/features/grades/services/grades-helper.ts
+++ b/src/core/features/grades/services/grades-helper.ts
@@ -118,6 +118,12 @@ export class CoreGradesHelperProvider {
                 row.gradeClass = column.class.includes('gradepass') ? 'text-success' :
                     (column.class.includes('gradefail') ? 'text-danger' : '');
 
+                if (content.includes('action-menu')) {
+                    content = CoreTextUtils.processHTML(content, (element) => {
+                        element.querySelector('.action-menu')?.parentElement?.remove();
+                    });
+                }
+
                 if (content.includes('fa-check')) {
                     row.gradeIcon = 'fas-check';
                     row.gradeIconAlt = Translate.instant('core.grades.pass');

--- a/src/core/services/utils/text.ts
+++ b/src/core/services/utils/text.ts
@@ -274,6 +274,21 @@ export class CoreTextUtilsProvider {
     }
 
     /**
+     * Process HTML string.
+     *
+     * @param text HTML string.
+     * @param process Method to process the HTML.
+     * @returns Processed HTML string.
+     */
+    processHTML(text: string, process: (element: HTMLElement) => unknown): string {
+        const element = this.convertToElement(text);
+
+        process(element);
+
+        return element.innerHTML;
+    }
+
+    /**
      * Clean HTML tags.
      *
      * @param text The text to be cleaned.


### PR DESCRIPTION
Right now, this menu is only used to link to the "Grade Analysis" because this link was removed from the LMS after some recent changes. But the mobile app never had this link, so we can safely remove the menu for now.