### PR TITLE
MOBILE-4553 quiz: Hide ungraded marks

### DIFF
--- a/src/addons/mod/quiz/pages/attempt/attempt.html
+++ b/src/addons/mod/quiz/pages/attempt/attempt.html
@@ -30,7 +30,7 @@
                     <p *ngFor="let sentence of attempt.readableState">{{ sentence }}</p>
                 </ion-label>
             </ion-item>
-            <ng-container *ngIf="attempt.finished">
+            <ng-container *ngIf="attempt.finished && attempt.sumgrades !== null">
                 <ion-item *ngFor="let gradeItemMark of attempt.gradeitemmarks ?? []" class="ion-text-wrap">
                     <ion-label>
                         <p class="item-heading">{{ gradeItemMark.name }} / {{ gradeItemMark.maxgrade }}</p>
@@ -38,7 +38,7 @@
                     </ion-label>
                 </ion-item>
             </ng-container>
-            <ion-item class="ion-text-wrap" *ngIf="quiz!.showMarkColumn && attempt.readableMark !== ''">
+            <ion-item class="ion-text-wrap" *ngIf="quiz!.showMarkColumn && attempt.readableMark !== '' && attempt.sumgrades !== null">
                 <ion-label>
                     <p class="item-heading">{{ 'addon.mod_quiz.marks' | translate }} / {{ quiz!.sumGradesFormatted }}</p>
                     <p>{{ attempt.readableMark }}</p>

--- a/src/addons/mod/quiz/pages/review/review.html
+++ b/src/addons/mod/quiz/pages/review/review.html
@@ -60,7 +60,7 @@
                         <p>{{ gradeItemMark.grade }}</p>
                     </ion-label>
                 </ion-item>
-                <ion-item class="ion-text-wrap" *ngIf="readableMark">
+                <ion-item class="ion-text-wrap" *ngIf="readableMark && attempt?.sumgrades !== null">
                     <ion-label>
                         <p class="item-heading">{{ 'addon.mod_quiz.marks' | translate }}</p>
                         <p>{{ readableMark }}</p>

--- a/src/addons/mod/quiz/pages/review/review.ts
+++ b/src/addons/mod/quiz/pages/review/review.ts
@@ -286,13 +286,17 @@ export class AddonModQuizReviewPage implements OnInit {
         }
 
         // Treat grade item marks.
-        this.gradeItemMarks = this.attempt.gradeitemmarks?.map((gradeItemMark) => ({
-            name: gradeItemMark.name,
-            grade: Translate.instant('addon.mod_quiz.outof', { $a: {
-                grade: AddonModQuiz.formatGrade(gradeItemMark.grade, this.quiz?.decimalpoints),
-                maxgrade: AddonModQuiz.formatGrade(gradeItemMark.maxgrade, this.quiz?.decimalpoints),
-            } }),
-        })) ?? [];
+        if (this.attempt.sumgrades === null || !this.attempt.gradeitemmarks) {
+            this.gradeItemMarks = [];
+        } else {
+            this.gradeItemMarks = this.attempt.gradeitemmarks.map((gradeItemMark) => ({
+                name: gradeItemMark.name,
+                grade: Translate.instant('addon.mod_quiz.outof', { $a: {
+                    grade: AddonModQuiz.formatGrade(gradeItemMark.grade, this.quiz?.decimalpoints),
+                    maxgrade: AddonModQuiz.formatGrade(gradeItemMark.maxgrade, this.quiz?.decimalpoints),
+                } }),
+            }));
+        }
 
         // Treat grade.
         if (this.options && this.options.someoptions.marks >= AddonModQuizProvider.QUESTION_OPTIONS_MARK_AND_MAX &&


### PR DESCRIPTION
This makes it consistent with the way it works in the LMS, we're also relying on attempt.sumgrades because grade item marks are never null. See MDL-81599.