### PR TITLE
MOBILE-4470 timeline: Avoid filtering past courses

### DIFF
--- a/src/addons/block/timeline/components/timeline/timeline.ts
+++ b/src/addons/block/timeline/components/timeline/timeline.ts
@@ -256,9 +256,8 @@ export class AddonBlockTimelineComponent implements OnInit, ICoreBlockComponent 
             .filter(
                 course =>
                     !course.hidden &&
-                !CoreCoursesHelper.isPastCourse(course, gracePeriod.after) &&
-                !CoreCoursesHelper.isFutureCourse(course, gracePeriod.after, gracePeriod.before) &&
-                courseEvents[course.id].events.length > 0,
+                    !CoreCoursesHelper.isFutureCourse(course, gracePeriod.after, gracePeriod.before) &&
+                    courseEvents[course.id].events.length > 0,
             )
             .map(course => {
                 const section = new AddonBlockTimelineSection(


### PR DESCRIPTION
This may have been introduced by mistake in commit https://github.com/moodlehq/moodleapp/commit/0f5416e2f0750da7aa5c015ffcfb2d12fd87ae32. Looking at improvements introduced in 4.0, past courses were never filtered out but the UI says "No in-progress courses" when empty; that may have caused the confusion.