### PR TITLE
MOBILE-4470 core: Refactor mod-icon to use signals

### DIFF
--- a/src/core/components/mod-icon/mod-icon.html
+++ b/src/core/components/mod-icon/mod-icon.html
@@ -1,6 +1,6 @@
-<ng-container *ngIf="loaded && !svgIcon">
-    <img *ngIf="!isLocalUrl" [url]="iconUrl" core-external-content alt="" [component]="linkIconWithComponent ? modname : null"
-        [componentId]="linkIconWithComponent ? componentId : null" (error)="loadFallbackIcon()">
-    <img *ngIf="isLocalUrl" [src]="iconUrl" (error)="loadFallbackIcon()" alt="">
+<ng-container *ngIf="loaded() && !svgIcon()">
+    <img *ngIf="!isLocalUrl()" [url]="iconUrl()" core-external-content alt="" [component]="linkIconWithComponent() ? modname : null"
+        [componentId]="linkIconWithComponent() ? componentId : null" (error)="loadFallbackIcon()">
+    <img *ngIf="isLocalUrl()" [src]="iconUrl()" (error)="loadFallbackIcon()" alt="">
 </ng-container>
-<div *ngIf="svgIcon" [innerHTML]="svgIcon"></div>
+<div *ngIf="svgIcon()" [innerHTML]="svgIcon()"></div>


### PR DESCRIPTION
This change is necessary because some icons weren't updated properly inside of components using OnPush (e.g. course-storage page).