### PR TITLE
MOBILE-4470 core: Inject mod-icon svg into Shadow DOM

### DIFF
--- a/src/core/components/mod-icon/mod-icon.html
+++ b/src/core/components/mod-icon/mod-icon.html
@@ -1,6 +1,6 @@
-<ng-container *ngIf="loaded() && !svgIcon()">
+<ng-container *ngIf="loaded() && !svgLoaded()">
     <img *ngIf="!isLocalUrl()" [url]="iconUrl()" core-external-content alt="" [component]="linkIconWithComponent() ? modname : null"
         [componentId]="linkIconWithComponent() ? componentId : null" (error)="loadFallbackIcon()">
     <img *ngIf="isLocalUrl()" [src]="iconUrl()" (error)="loadFallbackIcon()" alt="">
 </ng-container>
-<div *ngIf="svgIcon()" [innerHTML]="svgIcon()"></div>
+<div [hidden]="!svgLoaded()" #svg></div>

--- a/src/core/components/mod-icon/mod-icon.scss
+++ b/src/core/components/mod-icon/mod-icon.scss
@@ -40,7 +40,8 @@
             @each $type, $value in $activity-icon-background-colors {
                 &.#{$type}:not(.branded) {
                     background-color: var(--activity-40-#{$type});
-                    ::ng-deep svg, img {
+                    img,
+                    ::ng-deep ::part(svg) {
                         filter: brightness(0) invert(1);
                     }
                 }
@@ -58,14 +59,14 @@
     }
 
     &.colorize.version_current:not(.branded) {
-        ::ng-deep svg,
-        ::ng-deep svg * {
+        ::ng-deep ::part(svg),
+        ::ng-deep ::part(svg-child) {
             fill: var(--color) !important;
         }
     }
 
     img,
-    ::ng-deep svg {
+    ::ng-deep ::part(svg) {
         width: var(--size);
         height: var(--size);
         max-width: var(--size);


### PR DESCRIPTION
This was necessary in order to completely isolate the styles of an injected SVG. It was previously handled in https://github.com/moodlehq/moodleapp/commit/5735bc4ca96a793fdb555f91acde9ca167cc20d6, but that didn't suffice because some SVGs are styled using classes, not ids.

In v4.3 we didn't need to do any of this because SVGs were displayed using an img tag, so the styles were always isolated.