### PR TITLE
MOBILE-4842 behat: Disable a block site main menu test in 4.1

### DIFF
--- a/src/addons/block/sitemainmenu/tests/behat/block_sitemainmenu-405.feature
+++ b/src/addons/block/sitemainmenu/tests/behat/block_sitemainmenu-405.feature
@@ -21,6 +21,7 @@ Feature: Basic tests of Main menu block
     When I press "My forum name" in the app
     Then the header should be "My forum name" in the app
 
+  @lms_from4.3
   Scenario: Activities in main menu block can be made available but not visible on a course page
     Given the following config values are set as admin:
       | allowstealth | 1 |


### PR DESCRIPTION
The steps to make the block hidden but available changed in 4.3, so the test fails in 4.1. Since the support for 4.1 ends soon I disabled the test instead of creating a new file just for this test.