### PR TITLE
MOBILE-4842 ws: Fix bug when SSL error in Android

### DIFF
--- a/src/core/services/ws.ts
+++ b/src/core/services/ws.ts
@@ -1203,6 +1203,9 @@ export class CoreWSProvider {
                     // Error is a response object.
                     response = error as NativeHttpResponse;
 
+                    // If it's a SSL error, the response doesn't contain headers. Make sure it always exists, even if it's empty.
+                    response.headers = response.headers || {};
+
                     // Redirections should have been handled by the platform,
                     // but Android does not follow redirections between HTTP and HTTPS.
                     // See: https://developer.android.com/reference/java/net/HttpURLConnection#response-handling


### PR DESCRIPTION
If the certificate isn't trusted in Android, the error response doesn't contain headers so the code threw an exception and the proper error message was lost.