### PR TITLE
MOBILE-4842 behat: Disable assign overview behats in Jenkins

### DIFF
--- a/src/addons/mod/assign/tests/behat/overview.feature
+++ b/src/addons/mod/assign/tests/behat/overview.feature
@@ -1,4 +1,4 @@
-@addon_mod_assign @app @mod @mod_assign @javascript @lms_from5.1
+@addon_mod_assign @app @mod @mod_assign @javascript @lms_from5.1 @ci_jenkins_skip
 Feature: Activities overview for assign activity
 
   Background:


### PR DESCRIPTION
This is temporary until MDL-85981 code has been moved to main and MOBILE-4867 is integrated in the app