### PR TITLE
MOBILE-4842 behat: Fix error in @core_reminders tests

### DIFF
--- a/local_moodleappbehat/tests/behat/behat_app_helper.php
+++ b/local_moodleappbehat/tests/behat/behat_app_helper.php
@@ -367,7 +367,7 @@ class behat_app_helper extends behat_base {
      * @return mixed Result.
      */
     protected function runtime_js(string $script) {
-        return $this->evaluate_script("window.behat ? window.behat.$script : 'ERROR - Behat API not loaded'");
+        return $this->evaluate_script("window.behat ? await window.behat.$script : 'ERROR - Behat API not loaded'");
     }
 
     /**


### PR DESCRIPTION
The press action in Behat was sometimes throwing the error "Promise was collected". The cause of this error is unclear, but it can be prevented by adding an explicit await in the executed JS code.