### PR TITLE
MOBILE-5015 loading: Workaround to fix animation.leave not firing

### DIFF
--- a/src/core/components/loading/loading.ts
+++ b/src/core/components/loading/loading.ts
@@ -117,6 +117,18 @@ export class CoreLoadingComponent implements AsyncDirective, OnDestroy {
                 if (CorePlatform.isIOS()) {
                     this.mutationObserver.observe(this.element, { childList: true });
                 }
+
+                // Emulate leave animation by adding a class and removing the element after the animation is done.
+                // This is needed to solve animation.leave problem introduced in Angular 20.3.6.
+                // @TODO: Remove this workaround when updating to Angular v21, as the problem should be fixed by then.
+                const container = this.element.querySelector('.core-loading-container');
+                if (container && !container.classList.contains('hide-animation')) {
+                    container.classList.add('hide-animation');
+
+                    setTimeout(() => {
+                        container.remove();
+                    }, 500);
+                }
             } else {
                 this.mutationObserver.disconnect();
             }

--- a/src/theme/animations/show-hide.scss
+++ b/src/theme/animations/show-hide.scss
@@ -1,5 +1,6 @@
 
 .show-animation {
+    will-change: opacity;
     animation: fadeIn 500ms ease-in-out;
 }
 
@@ -14,6 +15,7 @@
 }
 
 .hide-animation {
+    will-change: opacity;
     animation: fadeOut 500ms ease-in-out;
 }
 


### PR DESCRIPTION
https://moodle.atlassian.net/browse/MOBILE-5015

Problem was introduced when changing the animation scheduling here:  . We’ve testing this is solved by reverting to 20.3.5 or updating angular to 21.2.0.

We’ve decided to make a workaround just to solve the issue in core-loading.